### PR TITLE
Distribute Python Packages

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,12 +12,28 @@ jobs:
     container:
       image: docker://ghcr.io/n3pdf/maturin:0.2.1
     steps:
+      - name: Set Path
+        run: |
+          echo "PATH=${HOME}/local/bin:${HOME}/.cargo/bin:${PATH}" >> $GITHUB_ENV
+      - name: Clone repository
+        run: |
+          cd ${HOME}
+          # clone pineappl code
+          git clone https://github.com/N3PDF/pineappl.git
+      - name: Compile and Publish CLI wheels
+        working-directory: /home/pineappl
+        env:
+          HOME: /home/pineappl
+        run: |
+          cd ${HOME}/pineappl/pineappl_cli
+          maturin publish --skip-existing --username __token__ --password ${{ secrets.PYPI_TOKEN }} -F fktable --no-sdist
       - name: Compile and Publish wheels
         working-directory: /home/pineappl
         env:
           HOME: /home/pineappl
         run: |
-          ~/maturin publish --skip-existing --username __token__ --password ${{ secrets.PYPI_TOKEN }} --interpreter 3.7 3.8 3.9 3.10 pypy3.7
+          cd ${HOME}/pineappl/pineappl_py
+          maturin publish --skip-existing --username __token__ --password ${{ secrets.PYPI_TOKEN }} --interpreter 3.7 3.8 3.9 3.10 3.11 pypy3.7 pypy3.8 pypy 3.9
 
   deploy-other:
     strategy:

--- a/pineappl_py/package/Containerfile
+++ b/pineappl_py/package/Containerfile
@@ -2,6 +2,8 @@ FROM quay.io/pypa/manylinux2014_x86_64
 
 ARG MATURIN_TAR='maturin-x86_64-unknown-linux-musl.tar.gz'
 ARG MATURIN_TAG='v0.13.0-beta.9'
+ARG LHAPDF_URL='https://lhapdf.hepforge.org/downloads/?f='
+ARG LHAPDF_TAG='LHAPDF-6.5.3'
 
 # install c compiler
 # and create a dedicated user
@@ -9,7 +11,11 @@ RUN /bin/bash -c "yum install gcc -y; \
                   useradd -m pineappl;\
                   su - pineappl"
 
-USER pineappl
+ARG USER=pineappl
+USER ${USER}
+ENV PATH=/home/${USER}/local/bin:/home/${USER}/.cargo/bin:${PATH}
+ENV PKG_CONFIG_PATH=/home/${USER}/local/lib/pkgconfig:PKG_CONFIG_PATH
+ENV LD_LIBRARY_PATH=/home/${USER}/local/lib:LD_LIBRARY_PATH
 
 # install dependencies
 # - rust
@@ -18,10 +24,7 @@ RUN /bin/bash -c "cd ${HOME}; \
                   mkdir -p local/bin; \
                   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; \
                   curl --remote-name -L https://github.com/PyO3/maturin/releases/download/${MATURIN_TAG}/${MATURIN_TAR}; \
-                  tar -xvzf ${MATURIN_TAR} --directory=local/bin/"
-
-COPY maturin /home/pineappl
-
-ENTRYPOINT ["/home/pineappl/maturin"]
-# To minimize the size of the wheel use '--strip'
-CMD ["build --release --interpreter 3.7 3.8 3.9 3.10 pypy3.7"]
+                  tar -xvzf ${MATURIN_TAR} --directory=local/bin/; \
+                  curl -L ${LHAPDF_URL}${LHAPDF_TAG}.tar.gz > LHAPDF.tar.gz; \
+                  tar xvzf LHAPDF.tar.gz; \
+                  cd ${LHAPDF_TAG}; ./configure --disable-python --prefix=${HOME}/local; make && make install"

--- a/pineappl_py/package/maturin
+++ b/pineappl_py/package/maturin
@@ -1,8 +1,0 @@
-#!/bin/bash
-export PATH=${HOME}/local/bin:${HOME}/.cargo/bin:${PATH}
-cd ${HOME}
-# clone pineappl code
-git clone https://github.com/N3PDF/pineappl.git
-# compile pineappl python package
-cd pineappl/pineappl_py
-maturin $@


### PR DESCRIPTION
Closes #177 

I already updated the container (notice that I remove the default entrypoint, now it runs interactively with bash), and the wheels releasing workflow.

Still, we have to:
- [ ] fix the missing symbol issue
- [ ] check the CI is actually working (non-trivial, we will just try at some point)
- [ ] update dependencies
     - i.e. make `pineappl` depedn on `pineappl_cli`, see #177