### PR TITLE
Add interfaces compatible with EKO v0.11.x

### DIFF
--- a/pineappl_py/pineappl/grid.py
+++ b/pineappl_py/pineappl/grid.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -256,7 +257,7 @@ class Grid(PyWrapper):
         alphas_values: Sequence[float],
         lumi_id_types: str = "pdg_mc_ids",
         order_mask: Sequence[float] = (),
-        xi: tuple[float, float] = (1.0, 1.0),
+        xi: Tuple[float, float] = (1.0, 1.0),
     ):
         """
         Create an FKTable with the EKO.
@@ -306,7 +307,15 @@ class Grid(PyWrapper):
             )
         )
 
-    def evolve(self, operators, mur2_grid, alphas_values, lumi_id_types="pdg_mc_ids", order_mask=(), xi=(1.0, 1.0)):
+    def evolve(
+        self,
+        operators,
+        mur2_grid,
+        alphas_values,
+        lumi_id_types="pdg_mc_ids",
+        order_mask=(),
+        xi=(1.0, 1.0),
+    ):
         """
         Create an FKTable with the EKO.
 

--- a/pineappl_py/pineappl/grid.py
+++ b/pineappl_py/pineappl/grid.py
@@ -1,5 +1,4 @@
-from collections.abc import Sequence
-from typing import Tuple
+from typing import Sequence, Tuple
 
 import numpy as np
 import numpy.typing as npt

--- a/pineappl_py/pineappl/grid.py
+++ b/pineappl_py/pineappl/grid.py
@@ -1,4 +1,7 @@
+from collections.abc import Sequence
+
 import numpy as np
+import numpy.typing as npt
 
 from .fk_table import FkTable
 from .pineappl import PyGrid, PyOrder
@@ -245,7 +248,16 @@ class Grid(PyWrapper):
             xi,
         )
 
-    def convolute_eko(self, operators, mur2_grid, alphas_values, lumi_id_types="pdg_mc_ids", order_mask=(), xi=(1.0, 1.0)):
+    def convolute_eko(
+        self,
+        operators: npt.NDArray,
+        muf2_grid: Sequence[float],
+        mur2_grid: Sequence[float],
+        alphas_values: Sequence[float],
+        lumi_id_types: str = "pdg_mc_ids",
+        order_mask: Sequence[float] = (),
+        xi: tuple[float, float] = (1.0, 1.0),
+    ):
         """
         Create an FKTable with the EKO.
 
@@ -253,8 +265,8 @@ class Grid(PyWrapper):
 
         Parameters
         ----------
-            operators : dict
-                EKO Output
+            operators : np.ndarray
+                array containing the concatenation of EKO operators
             mur2_grid : list[float]
                 renormalization scales
             alphas_values : list[float]
@@ -277,10 +289,6 @@ class Grid(PyWrapper):
             PyFkTable :
                 raw grid as an FKTable
         """
-        operator_grid = np.array(
-            [op["operators"] for op in operators["Q2grid"].values()]
-        )
-        q2grid = list(operators["Q2grid"].keys())
         return FkTable(
             self.raw.convolute_eko(
                 operators["q2_ref"],
@@ -290,11 +298,11 @@ class Grid(PyWrapper):
                 np.array(operators["inputpids"], dtype=np.int32),
                 np.array(operators["inputgrid"]),
                 np.array(mur2_grid, dtype=np.float64),
-                np.array(q2grid, dtype=np.float64),
-                np.array(operator_grid),
+                np.array(muf2_grid, dtype=np.float64),
+                np.array(operators),
                 lumi_id_types,
                 np.array(order_mask, dtype=bool),
-                xi
+                xi,
             )
         )
 


### PR DESCRIPTION
The best thing would be to be EKO independent, but this is not completely possible.

Furthermore, with the new structure will also be a not so clever idea, since we want to allow for very big EKOs, to be loaded one Q2 at a time.

So, for the future, we have two options:
1. either we find a way to pass a callable with a certain interface, and PineAPPL will query for operators, when needed
2. or we just make a Rust EKO library (needed in any case, NNPDF/eko#97, but will be extremely tiny), and have PineAPPL directly depend on it

For the time being, we just stick to the single operator, but I propose to move the construction out of PineAPPLpy

- [x] receive directly a concatenated array in `convolute_eko`
- [ ] same in `evolve`
- [ ] recover tests