### PR TITLE
Optimize `x1`- and `x2`-grids

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,11 +39,11 @@ jobs:
         ./configure --prefix=${HOME}/prefix --disable-static
         make -j
         make install
-    - name: Install Rust nightly
+    - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
         default: true
-        toolchain: nightly
+        toolchain: stable
         components: llvm-tools-preview
     - name: Get test data
       id: cache-test-data

--- a/pineappl/src/evolution.rs
+++ b/pineappl/src/evolution.rs
@@ -425,7 +425,10 @@ pub(crate) fn evolve_with_one(
         sub_fk_tables.extend(tables.into_iter().map(|table| {
             ImportOnlySubgridV2::new(
                 SparseArray3::from_ndarray(
-                    &table.insert_axis(Axis(0)).insert_axis(Axis(new_axis)),
+                    table
+                        .insert_axis(Axis(0))
+                        .insert_axis(Axis(new_axis))
+                        .view(),
                     0,
                     1,
                 ),
@@ -569,7 +572,7 @@ pub(crate) fn evolve_with_two(
 
         sub_fk_tables.extend(tables.into_iter().map(|table| {
             ImportOnlySubgridV2::new(
-                SparseArray3::from_ndarray(&table.insert_axis(Axis(0)), 0, 1),
+                SparseArray3::from_ndarray(table.insert_axis(Axis(0)).view(), 0, 1),
                 vec![Mu2 {
                     // TODO: FK tables don't depend on the renormalization scale
                     //ren: -1.0,

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1138,13 +1138,8 @@ impl Grid {
                             // we can't merge into an EmptySubgridV1
                             *lhs = rhs.clone_empty();
                             lhs.merge(rhs, false);
-                        } else if (lhs.x1_grid() == rhs.x1_grid())
-                            && (lhs.x2_grid() == rhs.x2_grid())
-                        {
-                            lhs.merge(rhs, false);
                         } else {
-                            // don't overwrite `rhs`
-                            continue;
+                            lhs.merge(rhs, false);
                         }
 
                         *rhs = EmptySubgridV1::default().into();

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -2436,7 +2436,7 @@ mod tests {
 
         let mut array = Array3::zeros((1, 3, 3));
         array[[0, 0, 0]] = 1.;
-        let sparse_array = SparseArray3::from_ndarray(&array, 0, 3);
+        let sparse_array = SparseArray3::from_ndarray(array.view(), 0, 3);
         let subgrid = ImportOnlySubgridV1::new(
             sparse_array,
             muf2_grid.clone(),

--- a/pineappl/src/import_only_subgrid.rs
+++ b/pineappl/src/import_only_subgrid.rs
@@ -387,13 +387,13 @@ impl From<&LagrangeSubgridV2> for ImportOnlySubgridV2 {
                     for ((_, ix1, ix2), entry) in array.indexed_iter_mut() {
                         *entry *= reweight_x1[ix1] * reweight_x2[ix2];
                     }
-                    SparseArray3::from_ndarray(&array, 0, 1)
+                    SparseArray3::from_ndarray(array.view(), 0, 1)
                 } else {
                     let mut array = array.clone();
                     for ((_, ix1, ix2), entry) in array.indexed_iter_mut() {
                         *entry *= reweight_x1[ix1] * reweight_x2[ix2];
                     }
-                    SparseArray3::from_ndarray(&array, 0, subgrid.itaumax - subgrid.itaumin)
+                    SparseArray3::from_ndarray(array.view(), 0, subgrid.itaumax - subgrid.itaumin)
                 }
             },
         );

--- a/pineappl/src/lagrange_subgrid.rs
+++ b/pineappl/src/lagrange_subgrid.rs
@@ -247,9 +247,16 @@ impl Subgrid for LagrangeSubgridV1 {
     }
 
     fn merge(&mut self, other: &mut SubgridEnum, transpose: bool) {
+        let x1_equal = self.x1_grid() == other.x1_grid();
+        let x2_equal = self.x2_grid() == other.x2_grid();
+
         if let SubgridEnum::LagrangeSubgridV1(other_grid) = other {
             if let Some(other_grid_grid) = &mut other_grid.grid {
                 if self.grid.is_some() {
+                    // TODO: the general case isn't implemented
+                    assert!(x1_equal);
+                    assert!(x2_equal);
+
                     let new_itaumin = self.itaumin.min(other_grid.itaumin);
                     let new_itaumax = self.itaumax.max(other_grid.itaumax);
                     let offset = other_grid.itaumin.saturating_sub(self.itaumin);
@@ -601,9 +608,16 @@ impl Subgrid for LagrangeSubgridV2 {
     }
 
     fn merge(&mut self, other: &mut SubgridEnum, transpose: bool) {
+        let x1_equal = self.x1_grid() == other.x1_grid();
+        let x2_equal = self.x2_grid() == other.x2_grid();
+
         if let SubgridEnum::LagrangeSubgridV2(other_grid) = other {
             if let Some(other_grid_grid) = &mut other_grid.grid {
                 if self.grid.is_some() {
+                    // TODO: the general case isn't implemented
+                    assert!(x1_equal);
+                    assert!(x2_equal);
+
                     let new_itaumin = self.itaumin.min(other_grid.itaumin);
                     let new_itaumax = self.itaumax.max(other_grid.itaumax);
                     let offset = other_grid.itaumin.saturating_sub(self.itaumin);
@@ -885,6 +899,10 @@ impl Subgrid for LagrangeSparseSubgridV1 {
             if self.array.is_empty() && !transpose {
                 mem::swap(&mut self.array, &mut other_grid.array);
             } else {
+                // TODO: the general case isn't implemented
+                assert!(self.x1_grid() == other_grid.x1_grid());
+                assert!(self.x2_grid() == other_grid.x2_grid());
+
                 // TODO: we need much more checks here if there subgrids are compatible at all
 
                 if transpose {

--- a/pineappl/src/lagrange_subgrid.rs
+++ b/pineappl/src/lagrange_subgrid.rs
@@ -959,7 +959,7 @@ impl From<&LagrangeSubgridV1> for LagrangeSparseSubgridV1 {
         Self {
             array: subgrid.grid.as_ref().map_or_else(
                 || SparseArray3::new(subgrid.ntau, subgrid.ny, subgrid.ny),
-                |grid| SparseArray3::from_ndarray(grid, subgrid.itaumin, subgrid.ntau),
+                |grid| SparseArray3::from_ndarray(grid.view(), subgrid.itaumin, subgrid.ntau),
             ),
             ntau: subgrid.ntau,
             ny: subgrid.ny,

--- a/pineappl/src/sparse_array3.rs
+++ b/pineappl/src/sparse_array3.rs
@@ -1,6 +1,6 @@
 //! Module containing the `SparseArray3` struct.
 
-use ndarray::{Array3, Axis};
+use ndarray::{ArrayView3, Axis};
 use serde::{Deserialize, Serialize};
 use std::iter;
 use std::mem;
@@ -256,7 +256,7 @@ impl<T: Clone + Default + PartialEq> SparseArray3<T> {
 
     /// Converts `array` into a `SparseArray3`.
     #[must_use]
-    pub fn from_ndarray(array: &Array3<T>, xstart: usize, xsize: usize) -> Self {
+    pub fn from_ndarray(array: ArrayView3<T>, xstart: usize, xsize: usize) -> Self {
         let (_, ny, nz) = array.dim();
         let array = if ny > nz {
             let mut array = array.clone();
@@ -432,6 +432,7 @@ impl<T: Clone + Default + PartialEq> SparseArray3<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ndarray::Array3;
 
     #[test]
     fn index_access() {
@@ -962,7 +963,7 @@ mod tests {
         ndarray[[0, 5, 7]] = 5.0;
         ndarray[[1, 3, 9]] = 6.0;
 
-        let array = SparseArray3::from_ndarray(&ndarray, 3, 40);
+        let array = SparseArray3::from_ndarray(ndarray.view(), 3, 40);
 
         assert_eq!(array[[3, 4, 3]], 1.0);
         assert_eq!(array[[3, 4, 4]], 2.0);
@@ -1048,7 +1049,7 @@ mod tests {
         ndarray[[4, 0, 0]] = 12.0;
         ndarray[[4, 0, 1]] = 13.0;
 
-        let mut other = SparseArray3::from_ndarray(&ndarray, 0, 5);
+        let mut other = SparseArray3::from_ndarray(ndarray.view(), 0, 5);
 
         assert_eq!(other[[0, 0, 0]], 1.0);
         assert_eq!(other[[0, 0, 1]], 2.0);


### PR DESCRIPTION
This will shrink the `x1`- and `x2`-grids such that the minimal and maximal values of each dimension reflect the range of non-zero subgrid values. That should also shrink the size of grids a bit (see https://github.com/NNPDF/pineappl/issues/151), however the main advantage is that one can now read off the x ranges for each subgrid, which can be helpful sometimes. Finally, the generation of EKOs should be faster since the operators have to be generated for fewer points.