### PR TITLE
Fix `Lagrange*` subgrid iterators

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,11 +39,11 @@ jobs:
         ./configure --prefix=${HOME}/prefix --disable-static
         make -j
         make install
-    - name: Install Rust nightly
+    - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
         default: true
-        toolchain: nightly
+        toolchain: stable
         components: llvm-tools-preview
     - name: Get test data
       id: cache-test-data

--- a/pineappl/src/empty_subgrid.rs
+++ b/pineappl/src/empty_subgrid.rs
@@ -1,7 +1,7 @@
 //! TODO
 
 use super::grid::Ntuple;
-use super::subgrid::{Mu2, Stats, Subgrid, SubgridEnum, SubgridIter};
+use super::subgrid::{Mu2, Stats, Subgrid, SubgridEnum, SubgridIndexedIter};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::iter;
@@ -53,7 +53,7 @@ impl Subgrid for EmptySubgridV1 {
         Self::default().into()
     }
 
-    fn iter(&self) -> SubgridIter {
+    fn indexed_iter(&self) -> SubgridIndexedIter {
         Box::new(iter::empty())
     }
 

--- a/pineappl/src/evolution.rs
+++ b/pineappl/src/evolution.rs
@@ -303,7 +303,7 @@ pub(crate) fn ndarray_from_subgrid_orders(
             })
             .collect::<Result<_, _>>()?;
 
-        for ((ifac1, ix1, ix2), value) in subgrid.iter() {
+        for ((ifac1, ix1, ix2), value) in subgrid.indexed_iter() {
             let mur2 = info.xir * info.xir * subgrid.mu2_grid()[ifac1].ren;
 
             let als = if order.alphas == 0 {

--- a/pineappl/src/fk_table.rs
+++ b/pineappl/src/fk_table.rs
@@ -153,8 +153,8 @@ impl FkTable {
 
         for bin in 0..self.bins() {
             for lumi in 0..self.grid.lumi().len() {
-                for ((_, ix1, ix2), value) in self.grid().subgrid(0, bin, lumi).iter() {
-                    subgrid[[bin, lumi, ix1, ix2]] = *value;
+                for ((_, ix1, ix2), value) in self.grid().subgrid(0, bin, lumi).indexed_iter() {
+                    subgrid[[bin, lumi, ix1, ix2]] = value;
                 }
             }
         }

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -612,7 +612,7 @@ impl Grid {
 
         let mut array = Array3::zeros((mu2_grid.len(), x1_grid.len(), x2_grid.len()));
 
-        for ((imu2, ix1, ix2), value) in subgrid.iter() {
+        for ((imu2, ix1, ix2), value) in subgrid.indexed_iter() {
             let x1 = x1_grid[ix1];
             let x2 = x2_grid[ix2];
             let mut lumi = 0.0;
@@ -1577,7 +1577,7 @@ impl Grid {
                         Vec::new()
                     };
 
-                    for ((iq2, ix1, ix2), &value) in src_subgrid.iter() {
+                    for ((iq2, ix1, ix2), value) in src_subgrid.indexed_iter() {
                         let scale = src_subgrid.mu2_grid()[iq2].fac;
                         let src_iq2 = src_array_q2_grid
                             .iter()
@@ -1753,7 +1753,7 @@ impl Grid {
                                 SubgridEnum::ImportOnlySubgridV2(ref mut array) => {
                                     let array = array.array_mut();
 
-                                    for ((_, tgt_x1_idx, tgt_x2_idx), &value) in
+                                    for ((_, tgt_x1_idx, tgt_x2_idx), value) in
                                         tgt_array.indexed_iter()
                                     {
                                         array[[0, tgt_x1_idx, tgt_x2_idx]] += value;

--- a/pineappl/src/ntuple_subgrid.rs
+++ b/pineappl/src/ntuple_subgrid.rs
@@ -1,7 +1,7 @@
 //! Provides an implementation of the `Grid` trait with n-tuples.
 
 use super::grid::Ntuple;
-use super::subgrid::{Mu2, Stats, Subgrid, SubgridEnum, SubgridIter};
+use super::subgrid::{Mu2, Stats, Subgrid, SubgridEnum, SubgridIndexedIter};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -70,7 +70,7 @@ impl Subgrid for NtupleSubgridV1 {
         Self::new().into()
     }
 
-    fn iter(&self) -> SubgridIter {
+    fn indexed_iter(&self) -> SubgridIndexedIter {
         unimplemented!();
     }
 
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn iter() {
-        let _ = NtupleSubgridV1::new().iter();
+        let _ = NtupleSubgridV1::new().indexed_iter();
     }
 
     #[test]

--- a/pineappl/src/sparse_array3.rs
+++ b/pineappl/src/sparse_array3.rs
@@ -142,8 +142,8 @@ pub struct IndexedIter<'a, T> {
     dimensions: (usize, usize, usize),
 }
 
-impl<'a, T: Default + PartialEq> Iterator for IndexedIter<'a, T> {
-    type Item = ((usize, usize, usize), &'a T);
+impl<'a, T: Copy + Default + PartialEq> Iterator for IndexedIter<'a, T> {
+    type Item = ((usize, usize, usize), T);
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(element) = self.entry_iter.next() {
@@ -179,7 +179,7 @@ impl<'a, T: Default + PartialEq> Iterator for IndexedIter<'a, T> {
                     self.tuple.1 += 1;
                     self.next()
                 } else {
-                    let result = Some((self.tuple, element));
+                    let result = Some((self.tuple, *element));
                     self.tuple.1 += 1;
                     result
                 }
@@ -212,7 +212,7 @@ impl<'a, T: Default + PartialEq> Iterator for IndexedIter<'a, T> {
                     self.tuple.2 += 1;
                     self.next()
                 } else {
-                    let result = Some((self.tuple, element));
+                    let result = Some((self.tuple, *element));
                     self.tuple.2 += 1;
                     result
                 }
@@ -350,7 +350,7 @@ impl<T: Clone + Default + PartialEq> SparseArray3<T> {
     }
 
     /// Return an indexed `Iterator` over the non-zero elements of this array. The iterator element
-    /// type is `((usize, usize, usize), &T)`.
+    /// type is `((usize, usize, usize), T)`.
     #[must_use]
     pub fn indexed_iter(&self) -> IndexedIter<'_, T> {
         IndexedIter::new(self)
@@ -708,7 +708,7 @@ mod tests {
         let mut iter = array.indexed_iter();
 
         // check iterator with one element
-        assert_eq!(iter.next(), Some(((2, 3, 4), &1.0)));
+        assert_eq!(iter.next(), Some(((2, 3, 4), 1.0)));
         assert_eq!(iter.next(), None);
 
         // insert another element
@@ -716,8 +716,8 @@ mod tests {
 
         let mut iter = array.indexed_iter();
 
-        assert_eq!(iter.next(), Some(((2, 3, 4), &1.0)));
-        assert_eq!(iter.next(), Some(((2, 3, 6), &2.0)));
+        assert_eq!(iter.next(), Some(((2, 3, 4), 1.0)));
+        assert_eq!(iter.next(), Some(((2, 3, 6), 2.0)));
         assert_eq!(iter.next(), None);
 
         // insert yet another element
@@ -725,9 +725,9 @@ mod tests {
 
         let mut iter = array.indexed_iter();
 
-        assert_eq!(iter.next(), Some(((2, 3, 4), &1.0)));
-        assert_eq!(iter.next(), Some(((2, 3, 6), &2.0)));
-        assert_eq!(iter.next(), Some(((4, 5, 7), &3.0)));
+        assert_eq!(iter.next(), Some(((2, 3, 4), 1.0)));
+        assert_eq!(iter.next(), Some(((2, 3, 6), 2.0)));
+        assert_eq!(iter.next(), Some(((4, 5, 7), 3.0)));
         assert_eq!(iter.next(), None);
 
         // insert at the very first position
@@ -735,10 +735,10 @@ mod tests {
 
         let mut iter = array.indexed_iter();
 
-        assert_eq!(iter.next(), Some(((2, 0, 0), &4.0)));
-        assert_eq!(iter.next(), Some(((2, 3, 4), &1.0)));
-        assert_eq!(iter.next(), Some(((2, 3, 6), &2.0)));
-        assert_eq!(iter.next(), Some(((4, 5, 7), &3.0)));
+        assert_eq!(iter.next(), Some(((2, 0, 0), 4.0)));
+        assert_eq!(iter.next(), Some(((2, 3, 4), 1.0)));
+        assert_eq!(iter.next(), Some(((2, 3, 6), 2.0)));
+        assert_eq!(iter.next(), Some(((4, 5, 7), 3.0)));
         assert_eq!(iter.next(), None);
     }
 
@@ -1017,19 +1017,19 @@ mod tests {
 
         let mut iter = array.indexed_iter();
 
-        assert_eq!(iter.next(), Some(((0, 0, 0), &1.0)));
-        assert_eq!(iter.next(), Some(((0, 0, 1), &2.0)));
-        assert_eq!(iter.next(), Some(((1, 6, 0), &5.0)));
-        assert_eq!(iter.next(), Some(((1, 8, 0), &6.0)));
-        assert_eq!(iter.next(), Some(((1, 9, 0), &7.0)));
-        assert_eq!(iter.next(), Some(((1, 2, 1), &3.0)));
-        assert_eq!(iter.next(), Some(((1, 5, 1), &4.0)));
-        assert_eq!(iter.next(), Some(((2, 0, 0), &8.0)));
-        assert_eq!(iter.next(), Some(((3, 4, 0), &10.0)));
-        assert_eq!(iter.next(), Some(((3, 2, 1), &9.0)));
-        assert_eq!(iter.next(), Some(((3, 4, 1), &11.0)));
-        assert_eq!(iter.next(), Some(((4, 0, 0), &12.0)));
-        assert_eq!(iter.next(), Some(((4, 0, 1), &13.0)));
+        assert_eq!(iter.next(), Some(((0, 0, 0), 1.0)));
+        assert_eq!(iter.next(), Some(((0, 0, 1), 2.0)));
+        assert_eq!(iter.next(), Some(((1, 6, 0), 5.0)));
+        assert_eq!(iter.next(), Some(((1, 8, 0), 6.0)));
+        assert_eq!(iter.next(), Some(((1, 9, 0), 7.0)));
+        assert_eq!(iter.next(), Some(((1, 2, 1), 3.0)));
+        assert_eq!(iter.next(), Some(((1, 5, 1), 4.0)));
+        assert_eq!(iter.next(), Some(((2, 0, 0), 8.0)));
+        assert_eq!(iter.next(), Some(((3, 4, 0), 10.0)));
+        assert_eq!(iter.next(), Some(((3, 2, 1), 9.0)));
+        assert_eq!(iter.next(), Some(((3, 4, 1), 11.0)));
+        assert_eq!(iter.next(), Some(((4, 0, 0), 12.0)));
+        assert_eq!(iter.next(), Some(((4, 0, 1), 13.0)));
         assert_eq!(iter.next(), None);
 
         let mut ndarray = Array3::zeros((5, 50, 2));

--- a/pineappl/src/subgrid.rs
+++ b/pineappl/src/subgrid.rs
@@ -108,7 +108,7 @@ pub trait Subgrid {
     fn clone_empty(&self) -> SubgridEnum;
 
     /// Return an iterator over all non-zero elements of the subgrid.
-    fn iter(&self) -> SubgridIter;
+    fn indexed_iter(&self) -> SubgridIndexedIter;
 
     /// Return statistics for this subgrid.
     fn stats(&self) -> Stats;
@@ -116,7 +116,7 @@ pub trait Subgrid {
 
 /// Type to iterate over the non-zero contents of a subgrid. The tuple contains the indices of the
 /// `mu2_grid`, the `x1_grid` and finally the `x2_grid`.
-pub type SubgridIter<'a> = Box<dyn Iterator<Item = ((usize, usize, usize), &'a f64)> + 'a>;
+pub type SubgridIndexedIter<'a> = Box<dyn Iterator<Item = ((usize, usize, usize), f64)> + 'a>;
 
 /// Subgrid creation parameters for subgrids that perform interpolation.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/pineappl_capi/src/lib.rs
+++ b/pineappl_capi/src/lib.rs
@@ -943,9 +943,9 @@ pub unsafe extern "C" fn pineappl_grid_export_mu2_slice(
     let x1_len = subgrid.x1_grid().len();
     let slice = slice::from_raw_parts_mut(buffer, x1_len * subgrid.x2_grid().len());
     subgrid
-        .iter()
+        .indexed_iter()
         .filter(|((imu2, _, _), _)| *imu2 == q2_slice)
-        .for_each(|((_, ix1, ix2), &value)| slice[ix1 + x1_len * ix2] = value);
+        .for_each(|((_, ix1, ix2), value)| slice[ix1 + x1_len * ix2] = value);
 }
 
 /// Write into `tuple` the lower and upper limit of filled q2 slices for the grid with the
@@ -964,7 +964,7 @@ pub unsafe extern "C" fn pineappl_grid_nonzero_mu2_slices(
     tuple: *mut usize,
 ) {
     let tuple = slice::from_raw_parts_mut(tuple, 2);
-    let mut iter = (*grid).subgrid(order, bin, lumi).iter();
+    let mut iter = (*grid).subgrid(order, bin, lumi).indexed_iter();
 
     if let Some(((first, _, _), _)) = iter.next() {
         tuple[0] = first;


### PR DESCRIPTION
This fixes <https://github.com/NNPDF/pineappl/issues/97>, but more importantly it will enable importing grids using `indexed_iter`. This will be needed for the new file format, see <https://github.com/NNPDF/pineappl/issues/118>.