### PR TITLE
Avoid copies in Python interface

### DIFF
--- a/pineappl/src/evolution.rs
+++ b/pineappl/src/evolution.rs
@@ -8,7 +8,7 @@ use super::sparse_array3::SparseArray3;
 use super::subgrid::{Mu2, Subgrid, SubgridEnum};
 use float_cmp::approx_eq;
 use itertools::Itertools;
-use ndarray::{s, Array1, Array2, Array3, Array5, ArrayView1, Axis};
+use ndarray::{s, Array1, Array2, Array3, ArrayView1, ArrayView5, Axis};
 use std::iter;
 
 /// Information about the evolution kernel operator (EKO) passed to [`Grid::evolve`] as `operator`,
@@ -81,7 +81,7 @@ fn gluon_has_pid_zero(grid: &Grid) -> bool {
 }
 
 pub(crate) fn pids(
-    operator: &Array5<f64>,
+    operator: &ArrayView5<f64>,
     info: &OperatorInfo,
     gluon_has_pid_zero: bool,
     pid1_nonzero: &dyn Fn(i32) -> bool,
@@ -146,7 +146,7 @@ pub(crate) fn lumi0_with_two(pids_a: &[(i32, i32)], pids_b: &[(i32, i32)]) -> Ve
 }
 
 pub(crate) fn operators(
-    operator: &Array5<f64>,
+    operator: &ArrayView5<f64>,
     info: &OperatorInfo,
     fac1: &[f64],
     pid_indices: &[(usize, usize)],
@@ -331,7 +331,7 @@ pub(crate) fn ndarray_from_subgrid_orders(
 
 pub(crate) fn evolve_with_one(
     grid: &Grid,
-    operator: &Array5<f64>,
+    operator: &ArrayView5<f64>,
     info: &OperatorInfo,
     order_mask: &[bool],
 ) -> Result<(Array3<SubgridEnum>, Vec<LumiEntry>), GridError> {
@@ -467,7 +467,7 @@ pub(crate) fn evolve_with_one(
 
 pub(crate) fn evolve_with_two(
     grid: &Grid,
-    operator: &Array5<f64>,
+    operator: &ArrayView5<f64>,
     info: &OperatorInfo,
     order_mask: &[bool],
 ) -> Result<(Array3<SubgridEnum>, Vec<LumiEntry>), GridError> {

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -17,7 +17,7 @@ use git_version::git_version;
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
-use ndarray::{s, Array3, Array5, Axis, Dimension};
+use ndarray::{s, Array3, Array5, ArrayView5, Axis, Dimension};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -1791,7 +1791,7 @@ impl Grid {
     /// incompatible with this `Grid`.
     pub fn evolve(
         &self,
-        operator: &Array5<f64>,
+        operator: ArrayView5<f64>,
         info: &OperatorInfo,
         order_mask: &[bool],
     ) -> Result<FkTable, GridError> {
@@ -1812,9 +1812,9 @@ impl Grid {
         }
 
         let (subgrids, lumi) = if self.has_pdf1() && self.has_pdf2() {
-            evolution::evolve_with_two(self, operator, info, order_mask)
+            evolution::evolve_with_two(self, &operator, info, order_mask)
         } else {
-            evolution::evolve_with_one(self, operator, info, order_mask)
+            evolution::evolve_with_one(self, &operator, info, order_mask)
         }?;
 
         let mut grid = Self {

--- a/pineappl_cli/src/evolve.rs
+++ b/pineappl_cli/src/evolve.rs
@@ -101,7 +101,7 @@ fn evolve_grid(
         })
         .collect();
 
-    Ok(grid.evolve(&operator, &info, &orders)?)
+    Ok(grid.evolve(operator.view(), &info, &orders)?)
 }
 
 #[cfg(not(feature = "fktable"))]

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -524,9 +524,9 @@ impl PyGrid {
         let evolved_grid = self
             .grid
             .evolve(
-                &operator.as_array().to_owned(),
+                operator.as_array(),
                 &op_info,
-                &order_mask.to_vec().unwrap(),
+                order_mask.as_slice().unwrap(),
             )
             .expect("Nothing returned from evolution.");
         PyFkTable {


### PR DESCRIPTION
This PR changes the Rust interface to use `ArrayView5` instead of `Array5`, which has the advantage of avoiding a full copy of the operator in `PyGrid::evolve`.