### PR TITLE
Expose the luminosity and bin mask options for FKs to the python interface

### DIFF
--- a/pineappl_py/pineappl/fk_table.py
+++ b/pineappl_py/pineappl/fk_table.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from .pineappl import PyFkTable, PyFkAssumptions
 from .utils import PyWrapper
 
@@ -49,6 +51,42 @@ class FkTable(PyWrapper):
         if not isinstance(assumptions,FkAssumptions):
             assumptions = FkAssumptions(assumptions)
         return self._raw.optimize(assumptions._raw)
+
+    def convolute_with_one(
+        self,
+        pdg_id,
+        xfx,
+        bin_indices=np.array([], dtype=np.uint64),
+        lumi_mask=np.array([], dtype=bool),
+    ):
+        r"""Convolute FkTable with a pdf.
+
+        Parameters
+        ----------
+            pdg_id : int
+                PDG Monte Carlo ID of the hadronic particle `xfx` is the PDF for
+            xfx : callable
+                lhapdf like callable with arguments `pid, x, Q2` returning x*pdf for :math:`x`-grid
+            bin_indices : sequence(int)
+                A list with the indices of the corresponding bins that should be calculated. An
+                empty list means that all orders should be calculated.
+            lumi_mask : sequence(bool)
+                Mask for selecting specific luminosity channels. The value `True` means the
+                corresponding channel is included. An empty list corresponds to all channels being
+                enabled.
+
+        Returns
+        -------
+            list(float) :
+                cross sections for all bins, for each scale-variation tuple (first all bins, then
+                the scale variation)
+        """
+        return self.raw.convolute_with_one(
+            pdg_id,
+            xfx,
+            np.array(bin_indices),
+            np.array(lumi_mask),
+        )
 
 
 class FkAssumptions(PyWrapper):

--- a/pineappl_py/pineappl/fk_table.py
+++ b/pineappl_py/pineappl/fk_table.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from .pineappl import PyFkTable, PyFkAssumptions
 from .utils import PyWrapper
 
@@ -51,42 +49,6 @@ class FkTable(PyWrapper):
         if not isinstance(assumptions,FkAssumptions):
             assumptions = FkAssumptions(assumptions)
         return self._raw.optimize(assumptions._raw)
-
-    def convolute_with_one(
-        self,
-        pdg_id,
-        xfx,
-        bin_indices=np.array([], dtype=np.uint64),
-        lumi_mask=np.array([], dtype=bool),
-    ):
-        r"""Convolute FkTable with a pdf.
-
-        Parameters
-        ----------
-            pdg_id : int
-                PDG Monte Carlo ID of the hadronic particle `xfx` is the PDF for
-            xfx : callable
-                lhapdf like callable with arguments `pid, x, Q2` returning x*pdf for :math:`x`-grid
-            bin_indices : sequence(int)
-                A list with the indices of the corresponding bins that should be calculated. An
-                empty list means that all orders should be calculated.
-            lumi_mask : sequence(bool)
-                Mask for selecting specific luminosity channels. The value `True` means the
-                corresponding channel is included. An empty list corresponds to all channels being
-                enabled.
-
-        Returns
-        -------
-            list(float) :
-                cross sections for all bins, for each scale-variation tuple (first all bins, then
-                the scale variation)
-        """
-        return self.raw.convolute_with_one(
-            pdg_id,
-            xfx,
-            np.array(bin_indices),
-            np.array(lumi_mask),
-        )
 
 
 class FkAssumptions(PyWrapper):

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -226,18 +226,12 @@ impl PyFkTable {
         let mut xfx = |id, x, q2| f64::extract(xfx.call1((id, x, q2)).unwrap()).unwrap();
         let mut alphas = |_| 1.0;
         let mut lumi_cache = LumiCache::with_one(pdg_id, &mut xfx, &mut alphas);
-        let bin_indices = if let Some(b) = bin_indices {
-            b.to_vec().unwrap()
-        } else {
-            vec![]
-        };
-        let lumi_mask = if let Some(l) = lumi_mask {
-            l.to_vec().unwrap()
-        } else {
-            vec![]
-        };
         self.fk_table
-            .convolute(&mut lumi_cache, &bin_indices, &lumi_mask)
+            .convolute(
+                &mut lumi_cache,
+                &bin_indices.map_or(vec![], |b| b.to_vec().unwrap()),
+                &lumi_mask.map_or(vec![], |l| l.to_vec().unwrap()),
+            )
             .into_pyarray(py)
     }
 

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -11,6 +11,8 @@ use std::io::BufReader;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::grid::PyGrid;
+
 /// PyO3 wrapper to :rustdoc:`pineappl::fk_table::FkTable <fk_table/struct.FkTable.html>`
 ///
 /// *Usage*: `pineko`, `yadism`
@@ -38,6 +40,13 @@ impl PyFkAssumptions {
 
 #[pymethods]
 impl PyFkTable {
+    #[new]
+    pub fn new(grid: PyGrid) -> Self {
+        Self {
+            fk_table: FkTable::try_from(grid.grid),
+        }
+    }
+
     #[staticmethod]
     pub fn read(path: PathBuf) -> Self {
         Self {

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -43,7 +43,7 @@ impl PyFkTable {
     #[new]
     pub fn new(grid: PyGrid) -> Self {
         Self {
-            fk_table: FkTable::try_from(grid.grid),
+            fk_table: FkTable::try_from(grid.grid).unwrap(),
         }
     }
 

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -214,6 +214,7 @@ impl PyFkTable {
     /// -------
     ///     numpy.ndarray(float) :
     ///         cross sections for all bins
+    #[pyo3(signature = (pdf_id, xfx, bin_indices = pyarray![].readonly(), lumi_cache = pyarray![].readonly()))]
     pub fn convolute_with_one<'py>(
         &self,
         pdg_id: i32,

--- a/pineappl_py/tests/test_fk_table.py
+++ b/pineappl_py/tests/test_fk_table.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+import pineappl
+
+
+class TestFkTable:
+    def fake_grid(self, bins=None):
+        lumis = [pineappl.lumi.LumiEntry([(1, 21, 0.1)])]
+        orders = [pineappl.grid.Order(3, 0, 0, 0)]
+        bin_limits = np.array([1e-7, 1e-3, 1] if bins is None else bins, dtype=float)
+        subgrid_params = pineappl.subgrid.SubgridParams()
+        g = pineappl.grid.Grid.create(lumis, orders, bin_limits, subgrid_params)
+        return g
+
+    def test_convolute_with_one(self):
+        g = self.fake_grid()
+
+        # DIS grid
+        xs = np.linspace(0.5, 1.0, 5)
+        vs = xs.copy()
+        subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
+            vs[np.newaxis, :, np.newaxis],
+            np.array([90.0]),
+            xs,
+            np.array([1.0]),
+        )
+        g.set_subgrid(0, 0, 0, subgrid)
+        fk = pineappl.fk_table.FkTable(g)
+        np.testing.assert_allclose(
+            fk.convolute_with_one(2212, lambda pid, x, q2: 0.0, lambda q2: 0.0),
+            [0.0] * 2,
+        )
+        np.testing.assert_allclose(
+            fk.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 1.0),
+            [5e6 / 9999, 0.0],
+        )
+        np.testing.assert_allclose(
+            fk.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 2.0),
+            [2**3 * 5e6 / 9999, 0.0],
+        )


### PR DESCRIPTION
It _seems_ to work. I've just copied it from the grid.