### PR TITLE
Make the CLI and extra dependency of the Python package

### DIFF
--- a/pineappl_py/pyproject.toml
+++ b/pineappl_py/pyproject.toml
@@ -21,10 +21,15 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
 ]
 
-dependencies = ["numpy>=1.16.0,<2.0.0"]
+dependencies = ["numpy>=1.16.0,<2.0.0", "pineappl-cli"]
 
 [project.optional-dependencies]
-docs = ["sphinx>=6.2.1", "sphinx_rtd_theme>=1.2.2", "sphinxcontrib-bibtex>=2.5.0", "nbsphinx>=0.9.2"]
+docs = [
+  "sphinx>=6.2.1",
+  "sphinx_rtd_theme>=1.2.2",
+  "sphinxcontrib-bibtex>=2.5.0",
+  "nbsphinx>=0.9.2",
+]
 test = ["pytest", "pytest-cov"]
 
 [project.urls]

--- a/pineappl_py/pyproject.toml
+++ b/pineappl_py/pyproject.toml
@@ -21,9 +21,10 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
 ]
 
-dependencies = ["numpy>=1.16.0,<2.0.0", "pineappl-cli"]
+dependencies = ["numpy>=1.16.0,<2.0.0"]
 
 [project.optional-dependencies]
+cli = ["pineappl-cli"]
 docs = [
   "sphinx>=6.2.1",
   "sphinx_rtd_theme>=1.2.2",


### PR DESCRIPTION
This is a tiny consequence of #266, just to simplify the installation.

It will cause an overhead, but I'd assume that most people running
```sh
pip install pineappl
```
would like to have the CLI as well.