### PR TITLE
Bump `pyo3` and `numpy` versions

### DIFF
--- a/.github/workflows/capi.yaml
+++ b/.github/workflows/capi.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - pycli
+      - bump-pyo3-version
 
 jobs:
   capi:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - pycli
+      - bump-pyo3-version
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - pycli
+      - bump-pyo3-version
 
 defaults:
   run:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef41cbb417ea83b30525259e30ccef6af39b31c240bda578889494c5392d331"
+checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -1326,6 +1326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "predicates"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,15 +1398,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1409,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1419,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1429,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1441,12 +1448,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/pineappl_py/Cargo.toml
+++ b/pineappl_py/Cargo.toml
@@ -29,6 +29,6 @@ crate-type = ["cdylib"]
 [dependencies]
 itertools = "0.10.1"
 ndarray = "0.15.4"
-numpy = "0.20.0"
+numpy = "0.21.0"
 pineappl = { path = "../pineappl", version = "=0.8.0" }
-pyo3 = { features = ["extension-module"], version = "0.20.0" }
+pyo3 = { features = ["extension-module"], version = "0.21.2" }

--- a/pineappl_py/src/bin.rs
+++ b/pineappl_py/src/bin.rs
@@ -1,6 +1,6 @@
 use pineappl::bin::BinRemapper;
 
-use numpy::PyReadonlyArray1;
+use numpy::{PyArrayMethods, PyReadonlyArray1};
 use pyo3::prelude::*;
 
 /// PyO3 wrapper to :rustdoc:`pineappl::bin::BinRemapper <bin/struct.BinRemapper.html>`

--- a/pineappl_py/src/evolution.rs
+++ b/pineappl_py/src/evolution.rs
@@ -14,26 +14,26 @@ pub struct PyEvolveInfo {
 impl PyEvolveInfo {
     /// Squared factorization scales of the `Grid`.
     #[getter]
-    fn fac1<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.evolve_info.fac1.clone().into_pyarray(py)
+    fn fac1<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.evolve_info.fac1.clone().into_pyarray_bound(py)
     }
 
     /// Particle identifiers of the `Grid`.
     #[getter]
-    fn pids1<'py>(&self, py: Python<'py>) -> &'py PyArray1<i32> {
-        self.evolve_info.pids1.clone().into_pyarray(py)
+    fn pids1<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i32>> {
+        self.evolve_info.pids1.clone().into_pyarray_bound(py)
     }
 
     /// `x`-grid coordinates of the `Grid`.
     #[getter]
-    fn x1<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.evolve_info.x1.clone().into_pyarray(py)
+    fn x1<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.evolve_info.x1.clone().into_pyarray_bound(py)
     }
 
     /// Renormalization scales of the `Grid`.
     #[getter]
-    fn ren1<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.evolve_info.ren1.clone().into_pyarray(py)
+    fn ren1<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.evolve_info.ren1.clone().into_pyarray_bound(py)
     }
 }
 

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -227,12 +227,12 @@ impl PyFkTable {
     pub fn convolve_with_one<'py>(
         &self,
         pdg_id: i32,
-        xfx: &PyAny,
+        xfx: &Bound<'py, PyAny>,
         bin_indices: Option<PyReadonlyArray1<usize>>,
         lumi_mask: Option<PyReadonlyArray1<bool>>,
         py: Python<'py>,
     ) -> Bound<'py, PyArray1<f64>> {
-        let mut xfx = |id, x, q2| f64::extract(xfx.call1((id, x, q2)).unwrap()).unwrap();
+        let mut xfx = |id, x, q2| xfx.call1((id, x, q2)).unwrap().extract().unwrap();
         let mut alphas = |_| 1.0;
         let mut lumi_cache = LumiCache::with_one(pdg_id, &mut xfx, &mut alphas);
         self.fk_table

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -63,8 +63,8 @@ impl PyFkTable {
     /// -------
     ///     numpy.ndarray :
     ///         4-dimensional tensor with indixes: bin, lumi, x1, x2
-    pub fn table<'a>(&self, py: Python<'a>) -> PyResult<&'a PyArray4<f64>> {
-        Ok(self.fk_table.table().into_pyarray(py))
+    pub fn table<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray4<f64>>> {
+        Ok(self.fk_table.table().into_pyarray_bound(py))
     }
 
     /// Get number of bins.
@@ -83,8 +83,8 @@ impl PyFkTable {
     /// -------
     ///     numpy.ndarray
     ///         bin normalizations
-    pub fn bin_normalizations<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.fk_table.bin_normalizations().into_pyarray(py)
+    pub fn bin_normalizations<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.fk_table.bin_normalizations().into_pyarray_bound(py)
     }
 
     /// Extract the number of dimensions for bins.
@@ -110,8 +110,8 @@ impl PyFkTable {
     /// -------
     ///     numpy.ndarray(float) :
     ///         left edges of bins
-    pub fn bin_left<'py>(&self, dimension: usize, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.fk_table.bin_left(dimension).into_pyarray(py)
+    pub fn bin_left<'py>(&self, dimension: usize, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.fk_table.bin_left(dimension).into_pyarray_bound(py)
     }
 
     /// Extract the right edges of a specific bin dimension.
@@ -125,8 +125,8 @@ impl PyFkTable {
     /// -------
     ///     numpy.ndarray(float) :
     ///         right edges of bins
-    pub fn bin_right<'py>(&self, dimension: usize, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.fk_table.bin_right(dimension).into_pyarray(py)
+    pub fn bin_right<'py>(&self, dimension: usize, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.fk_table.bin_right(dimension).into_pyarray_bound(py)
     }
 
     /// Get metadata values stored in the grid.
@@ -178,8 +178,8 @@ impl PyFkTable {
     /// -------
     ///     x_grid : numpy.ndarray(float)
     ///         interpolation grid
-    pub fn x_grid<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.fk_table.x_grid().into_pyarray(py)
+    pub fn x_grid<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.fk_table.x_grid().into_pyarray_bound(py)
     }
 
     /// Write grid to file.
@@ -231,7 +231,7 @@ impl PyFkTable {
         bin_indices: Option<PyReadonlyArray1<usize>>,
         lumi_mask: Option<PyReadonlyArray1<bool>>,
         py: Python<'py>,
-    ) -> &'py PyArray1<f64> {
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut xfx = |id, x, q2| f64::extract(xfx.call1((id, x, q2)).unwrap()).unwrap();
         let mut alphas = |_| 1.0;
         let mut lumi_cache = LumiCache::with_one(pdg_id, &mut xfx, &mut alphas);
@@ -241,7 +241,7 @@ impl PyFkTable {
                 &bin_indices.map_or(vec![], |b| b.to_vec().unwrap()),
                 &lumi_mask.map_or(vec![], |l| l.to_vec().unwrap()),
             )
-            .into_pyarray(py)
+            .into_pyarray_bound(py)
     }
 
     /// Optimize FK table storage

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -2,7 +2,7 @@ use pineappl::convolutions::LumiCache;
 use pineappl::fk_table::{FkAssumptions, FkTable};
 use pineappl::grid::Grid;
 
-use numpy::{IntoPyArray, PyArray1, PyArray4, PyReadonlyArray1};
+use numpy::{IntoPyArray, PyArray1, PyArray4, PyArrayMethods, PyReadonlyArray1};
 use pyo3::prelude::*;
 
 use std::collections::HashMap;

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -12,7 +12,9 @@ use super::lumi::PyLumiEntry;
 use super::subgrid::{PySubgridEnum, PySubgridParams};
 
 use itertools::izip;
-use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1, PyReadonlyArray4, PyReadonlyArray5};
+use numpy::{
+    IntoPyArray, PyArray1, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray4, PyReadonlyArray5,
+};
 
 use std::collections::HashMap;
 use std::fs::File;

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -386,16 +386,17 @@ impl PyGrid {
     pub fn convolve_with_one<'py>(
         &self,
         pdg_id: i32,
-        xfx: &PyAny,
-        alphas: &PyAny,
+        xfx: &Bound<'py, PyAny>,
+        alphas: &Bound<'py, PyAny>,
         order_mask: PyReadonlyArray1<bool>,
         bin_indices: PyReadonlyArray1<usize>,
         lumi_mask: PyReadonlyArray1<bool>,
         xi: Vec<(f64, f64)>,
         py: Python<'py>,
     ) -> Bound<'py, PyArray1<f64>> {
-        let mut xfx = |id, x, q2| f64::extract(xfx.call1((id, x, q2)).unwrap()).unwrap();
-        let mut alphas = |q2| f64::extract(alphas.call1((q2,)).unwrap()).unwrap();
+        let mut xfx = |id, x, q2| xfx.call1((id, x, q2)).unwrap().extract().unwrap();
+        // `(q2, )` must have the comma to make it a Rust tuple
+        let mut alphas = |q2| alphas.call1((q2,)).unwrap().extract().unwrap();
         let mut lumi_cache = LumiCache::with_one(pdg_id, &mut xfx, &mut alphas);
         self.grid
             .convolve(
@@ -449,19 +450,20 @@ impl PyGrid {
     pub fn convolve_with_two<'py>(
         &self,
         pdg_id1: i32,
-        xfx1: &PyAny,
+        xfx1: &Bound<'py, PyAny>,
         pdg_id2: i32,
-        xfx2: &PyAny,
-        alphas: &PyAny,
+        xfx2: &Bound<'py, PyAny>,
+        alphas: &Bound<'py, PyAny>,
         order_mask: PyReadonlyArray1<bool>,
         bin_indices: PyReadonlyArray1<usize>,
         lumi_mask: PyReadonlyArray1<bool>,
         xi: Vec<(f64, f64)>,
         py: Python<'py>,
     ) -> Bound<'py, PyArray1<f64>> {
-        let mut xfx1 = |id, x, q2| f64::extract(xfx1.call1((id, x, q2)).unwrap()).unwrap();
-        let mut xfx2 = |id, x, q2| f64::extract(xfx2.call1((id, x, q2)).unwrap()).unwrap();
-        let mut alphas = |q2| f64::extract(alphas.call1((q2,)).unwrap()).unwrap();
+        let mut xfx1 = |id, x, q2| xfx1.call1((id, x, q2)).unwrap().extract().unwrap();
+        let mut xfx2 = |id, x, q2| xfx2.call1((id, x, q2)).unwrap().extract().unwrap();
+        // `(q2, )` must have the comma to make it a Rust tuple
+        let mut alphas = |q2| alphas.call1((q2,)).unwrap().extract().unwrap();
         let mut lumi_cache =
             LumiCache::with_two(pdg_id1, &mut xfx1, pdg_id2, &mut xfx2, &mut alphas);
         self.grid
@@ -577,9 +579,9 @@ impl PyGrid {
     /// Returns
     /// -------
     /// TODO
-    pub fn evolve_with_slice_iter(
+    pub fn evolve_with_slice_iter<'py>(
         &self,
-        slices: &PyIterator,
+        slices: &Bound<'py, PyIterator>,
         order_mask: PyReadonlyArray1<bool>,
         xi: (f64, f64),
         ren1: Vec<f64>,

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -138,14 +138,14 @@ impl PyOrder {
         max_al: u32,
         logs: bool,
         py: Python<'py>,
-    ) -> &'py PyArray1<bool> {
+    ) -> Bound<'py, PyArray1<bool>> {
         Order::create_mask(
             &orders.iter().map(|o| o.order.clone()).collect::<Vec<_>>(),
             max_as,
             max_al,
             logs,
         )
-        .into_pyarray(py)
+        .into_pyarray_bound(py)
     }
 }
 
@@ -393,7 +393,7 @@ impl PyGrid {
         lumi_mask: PyReadonlyArray1<bool>,
         xi: Vec<(f64, f64)>,
         py: Python<'py>,
-    ) -> &'py PyArray1<f64> {
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut xfx = |id, x, q2| f64::extract(xfx.call1((id, x, q2)).unwrap()).unwrap();
         let mut alphas = |q2| f64::extract(alphas.call1((q2,)).unwrap()).unwrap();
         let mut lumi_cache = LumiCache::with_one(pdg_id, &mut xfx, &mut alphas);
@@ -405,7 +405,7 @@ impl PyGrid {
                 &lumi_mask.to_vec().unwrap(),
                 &xi,
             )
-            .into_pyarray(py)
+            .into_pyarray_bound(py)
     }
 
     /// Convolute grid with two pdfs.
@@ -458,7 +458,7 @@ impl PyGrid {
         lumi_mask: PyReadonlyArray1<bool>,
         xi: Vec<(f64, f64)>,
         py: Python<'py>,
-    ) -> &'py PyArray1<f64> {
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut xfx1 = |id, x, q2| f64::extract(xfx1.call1((id, x, q2)).unwrap()).unwrap();
         let mut xfx2 = |id, x, q2| f64::extract(xfx2.call1((id, x, q2)).unwrap()).unwrap();
         let mut alphas = |q2| f64::extract(alphas.call1((q2,)).unwrap()).unwrap();
@@ -472,7 +472,7 @@ impl PyGrid {
                 &lumi_mask.to_vec().unwrap(),
                 &xi,
             )
-            .into_pyarray(py)
+            .into_pyarray_bound(py)
     }
 
     /// Convolute with grid with an evolution operator.
@@ -700,8 +700,8 @@ impl PyGrid {
     /// -------
     ///     np.ndarray
     ///         bin normalizations
-    pub fn bin_normalizations<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.grid.bin_info().normalizations().into_pyarray(py)
+    pub fn bin_normalizations<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.grid.bin_info().normalizations().into_pyarray_bound(py)
     }
 
     /// Extract the left edges of a specific bin dimension.
@@ -717,8 +717,8 @@ impl PyGrid {
     /// -------
     ///     numpy.ndarray(float) :
     ///         left edges of bins
-    pub fn bin_left<'py>(&self, dimension: usize, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.grid.bin_info().left(dimension).into_pyarray(py)
+    pub fn bin_left<'py>(&self, dimension: usize, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.grid.bin_info().left(dimension).into_pyarray_bound(py)
     }
 
     /// Extract the right edges of a specific bin dimension.
@@ -734,8 +734,8 @@ impl PyGrid {
     /// -------
     ///     numpy.ndarray(float) :
     ///         right edges of bins
-    pub fn bin_right<'py>(&self, dimension: usize, py: Python<'py>) -> &'py PyArray1<f64> {
-        self.grid.bin_info().right(dimension).into_pyarray(py)
+    pub fn bin_right<'py>(&self, dimension: usize, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.grid.bin_info().right(dimension).into_pyarray_bound(py)
     }
 
     /// Return the number of bins.

--- a/pineappl_py/src/import_only_subgrid.rs
+++ b/pineappl_py/src/import_only_subgrid.rs
@@ -1,6 +1,6 @@
 use super::subgrid::PySubgridEnum;
 
-use numpy::{PyReadonlyArray1, PyReadonlyArray3};
+use numpy::{PyArrayMethods, PyReadonlyArray1, PyReadonlyArray3};
 use pineappl::import_only_subgrid::ImportOnlySubgridV1;
 use pineappl::import_only_subgrid::ImportOnlySubgridV2;
 use pineappl::sparse_array3::SparseArray3;
@@ -26,7 +26,11 @@ impl PyImportOnlySubgridV2 {
         x1_grid: PyReadonlyArray1<f64>,
         x2_grid: PyReadonlyArray1<f64>,
     ) -> Self {
-        let mut sparse_array = SparseArray3::new(mu2_grid.len(), x1_grid.len(), x2_grid.len());
+        let mut sparse_array = SparseArray3::new(
+            mu2_grid.len(),
+            x1_grid.as_slice().unwrap().len(),
+            x2_grid.as_slice().unwrap().len(),
+        );
 
         for ((imu2, ix1, ix2), value) in array
             .as_array()
@@ -91,7 +95,11 @@ impl PyImportOnlySubgridV1 {
         x1_grid: PyReadonlyArray1<f64>,
         x2_grid: PyReadonlyArray1<f64>,
     ) -> Self {
-        let mut sparse_array = SparseArray3::new(q2_grid.len(), x1_grid.len(), x2_grid.len());
+        let mut sparse_array = SparseArray3::new(
+            q2_grid.as_slice().unwrap().len(),
+            x1_grid.as_slice().unwrap().len(),
+            x2_grid.as_slice().unwrap().len(),
+        );
 
         for ((iq2, ix1, ix2), value) in array
             .as_array()

--- a/pineappl_py/src/lib.rs
+++ b/pineappl_py/src/lib.rs
@@ -15,7 +15,7 @@ pub mod subgrid;
 ///
 /// NOTE: this name has to match the one in Cargo.toml 'lib.name'
 #[pymodule]
-fn pineappl(_py: Python, m: &PyModule) -> PyResult<()> {
+fn pineappl(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<bin::PyBinRemapper>()?;
     m.add_class::<evolution::PyEvolveInfo>()?;
     m.add_class::<grid::PyGrid>()?;

--- a/pineappl_py/src/subgrid.rs
+++ b/pineappl_py/src/subgrid.rs
@@ -205,8 +205,8 @@ impl PySubgridEnum {
     }
 
     /// Return the dense array of the subgrid.
-    pub fn to_array3<'py>(&self, py: Python<'py>) -> &'py PyArray3<f64> {
-        Array3::from(&self.subgrid_enum).into_pyarray(py)
+    pub fn to_array3<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        Array3::from(&self.subgrid_enum).into_pyarray_bound(py)
     }
 
     pub fn into(&self) -> Self {

--- a/pineappl_py/src/subgrid.rs
+++ b/pineappl_py/src/subgrid.rs
@@ -222,11 +222,11 @@ impl PySubgridEnum {
             .collect()
     }
     /// Return the array of x1 of a subgrid
-    pub fn x1_grid<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
-        PyArray1::from_slice(py, &self.subgrid_enum.x1_grid())
+    pub fn x1_grid<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_slice_bound(py, &self.subgrid_enum.x1_grid())
     }
     /// Return the array of x2 of a subgrid
-    pub fn x2_grid<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
-        PyArray1::from_slice(py, &self.subgrid_enum.x2_grid())
+    pub fn x2_grid<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        PyArray1::from_slice_bound(py, &self.subgrid_enum.x2_grid())
     }
 }


### PR DESCRIPTION
I'd like to improve the Python API a bit, and since we're lagging a bit behind the `pyo3` versions we should update it first. It seems we can't update to `pyo3-0.22` yet, due to `numpy-0.21` requiring `pyo3-0.21`:

```
error: failed to select a version for `pyo3`.
    ... required by package `numpy v0.21.0`
    ... which satisfies dependency `numpy = "^0.21.0"` of package `pineappl_py v0.8.0 (/home/cschwan/projects/pineappl/pineappl_py)`
versions that meet the requirements `^0.21.0` are: 0.21.2, 0.21.1, 0.21.0

the package `pyo3` links to the native library `python`, but it conflicts with a previous package which links to `python` as well:
package `pyo3 v0.22.0`
    ... which satisfies dependency `pyo3 = "^0.22"` of package `pineappl_py v0.8.0 (/home/cschwan/projects/pineappl/pineappl_py)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "python"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.
```