### PR TITLE
Fix Python list arguments

### DIFF
--- a/pineappl_py/src/bin.rs
+++ b/pineappl_py/src/bin.rs
@@ -1,6 +1,5 @@
 //! Binnning interface.
 
-use numpy::{PyArrayMethods, PyReadonlyArray1};
 use pineappl::bin::BinRemapper;
 use pyo3::prelude::*;
 
@@ -23,9 +22,9 @@ impl PyBinRemapper {
     /// limits : list(tuple(float, float))
     ///     bin limits
     #[new]
-    pub fn new(normalizations: PyReadonlyArray1<f64>, limits: Vec<(f64, f64)>) -> Self {
+    pub fn new(normalizations: Vec<f64>, limits: Vec<(f64, f64)>) -> Self {
         Self {
-            bin_remapper: BinRemapper::new(normalizations.to_vec().unwrap(), limits).unwrap(),
+            bin_remapper: BinRemapper::new(normalizations, limits).unwrap(),
         }
     }
 }

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -1,7 +1,7 @@
 //! FK table interface.
 
 use super::grid::PyGrid;
-use numpy::{IntoPyArray, PyArray1, PyArray4, PyArrayMethods, PyReadonlyArray1};
+use numpy::{IntoPyArray, PyArray1, PyArray4};
 use pineappl::convolutions::LumiCache;
 use pineappl::fk_table::{FkAssumptions, FkTable};
 use pineappl::grid::Grid;
@@ -238,8 +238,8 @@ impl PyFkTable {
         &self,
         pdg_id: i32,
         xfx: &Bound<'py, PyAny>,
-        bin_indices: Option<PyReadonlyArray1<usize>>,
-        channel_mask: Option<PyReadonlyArray1<bool>>,
+        bin_indices: Option<Vec<usize>>,
+        channel_mask: Option<Vec<bool>>,
         py: Python<'py>,
     ) -> Bound<'py, PyArray1<f64>> {
         let mut xfx = |id, x, q2| xfx.call1((id, x, q2)).unwrap().extract().unwrap();
@@ -248,8 +248,8 @@ impl PyFkTable {
         self.fk_table
             .convolve(
                 &mut lumi_cache,
-                &bin_indices.map_or(vec![], |b| b.to_vec().unwrap()),
-                &channel_mask.map_or(vec![], |l| l.to_vec().unwrap()),
+                &bin_indices.unwrap_or_default(),
+                &channel_mask.unwrap_or_default(),
             )
             .into_pyarray_bound(py)
     }
@@ -278,8 +278,8 @@ impl PyFkTable {
         xfx1: &Bound<'py, PyAny>,
         pdg_id2: i32,
         xfx2: &Bound<'py, PyAny>,
-        bin_indices: Option<PyReadonlyArray1<usize>>,
-        channel_mask: Option<PyReadonlyArray1<bool>>,
+        bin_indices: Option<Vec<usize>>,
+        channel_mask: Option<Vec<bool>>,
         py: Python<'py>,
     ) -> Bound<'py, PyArray1<f64>> {
         let mut xfx1 = |id, x, q2| xfx1.call1((id, x, q2)).unwrap().extract().unwrap();
@@ -290,8 +290,8 @@ impl PyFkTable {
         self.fk_table
             .convolve(
                 &mut lumi_cache,
-                &bin_indices.map_or(vec![], |b| b.to_vec().unwrap()),
-                &channel_mask.map_or(vec![], |l| l.to_vec().unwrap()),
+                &bin_indices.unwrap_or_default(),
+                &channel_mask.unwrap_or_default(),
             )
             .into_pyarray_bound(py)
     }

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -280,9 +280,9 @@ impl PyGrid {
         self.grid
             .convolve(
                 &mut lumi_cache,
-                &order_mask.unwrap_or(vec![]),
-                &bin_indices.unwrap_or(vec![]),
-                &channel_mask.unwrap_or(vec![]),
+                &order_mask.unwrap_or_default(),
+                &bin_indices.unwrap_or_default(),
+                &channel_mask.unwrap_or_default(),
                 &xi.unwrap_or(vec![(1.0, 1.0)]),
             )
             .into_pyarray_bound(py)
@@ -347,9 +347,9 @@ impl PyGrid {
         self.grid
             .convolve(
                 &mut lumi_cache,
-                &order_mask.unwrap_or(vec![]),
-                &bin_indices.unwrap_or(vec![]),
-                &channel_mask.unwrap_or(vec![]),
+                &order_mask.unwrap_or_default(),
+                &bin_indices.unwrap_or_default(),
+                &channel_mask.unwrap_or_default(),
                 &xi.unwrap_or(vec![(1.0, 1.0)]),
             )
             .into_pyarray_bound(py)

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -365,7 +365,7 @@ impl PyGrid {
     /// Returns
     /// -------
     /// PyEvolveInfo :
-    ///     evolution informations
+    ///     evolution information
     pub fn evolve_info(&self, order_mask: PyReadonlyArray1<bool>) -> PyEvolveInfo {
         PyEvolveInfo {
             evolve_info: self.grid.evolve_info(order_mask.as_slice().unwrap()),

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -413,7 +413,6 @@ impl PyGrid {
                         CowArray::from(op.as_array().to_owned()),
                     ))
                 }),
-                // TODO: make `order_mask` a `Vec<f64>`
                 &order_mask,
                 xi,
                 &AlphasTable { ren1, alphas },
@@ -478,7 +477,6 @@ impl PyGrid {
                         CowArray::from(op.as_array().to_owned()),
                     ))
                 }),
-                // TODO: make `order_mask` a `Vec<f64>`
                 &order_mask,
                 xi,
                 &AlphasTable { ren1, alphas },

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -267,9 +267,9 @@ impl PyGrid {
         pdg_id: i32,
         xfx: &Bound<'py, PyAny>,
         alphas: &Bound<'py, PyAny>,
-        order_mask: Option<PyReadonlyArray1<bool>>,
-        bin_indices: Option<PyReadonlyArray1<usize>>,
-        channel_mask: Option<PyReadonlyArray1<bool>>,
+        order_mask: Option<Vec<bool>>,
+        bin_indices: Option<Vec<usize>>,
+        channel_mask: Option<Vec<bool>>,
         xi: Option<Vec<(f64, f64)>>,
         py: Python<'py>,
     ) -> Bound<'py, PyArray1<f64>> {
@@ -280,9 +280,9 @@ impl PyGrid {
         self.grid
             .convolve(
                 &mut lumi_cache,
-                &order_mask.map_or(vec![], |b| b.to_vec().unwrap()),
-                &bin_indices.map_or(vec![], |c| c.to_vec().unwrap()),
-                &channel_mask.map_or(vec![], |d| d.to_vec().unwrap()),
+                &order_mask.map_or(vec![], |b| b.to_vec()),
+                &bin_indices.map_or(vec![], |c| c.to_vec()),
+                &channel_mask.map_or(vec![], |d| d.to_vec()),
                 &xi.map_or(vec![(1.0, 1.0)], |m| m),
             )
             .into_pyarray_bound(py)
@@ -332,9 +332,9 @@ impl PyGrid {
         pdg_id2: i32,
         xfx2: &Bound<'py, PyAny>,
         alphas: &Bound<'py, PyAny>,
-        order_mask: Option<PyReadonlyArray1<bool>>,
-        bin_indices: Option<PyReadonlyArray1<usize>>,
-        channel_mask: Option<PyReadonlyArray1<bool>>,
+        order_mask: Option<Vec<bool>>,
+        bin_indices: Option<Vec<usize>>,
+        channel_mask: Option<Vec<bool>>,
         xi: Option<Vec<(f64, f64)>>,
         py: Python<'py>,
     ) -> Bound<'py, PyArray1<f64>> {
@@ -347,9 +347,9 @@ impl PyGrid {
         self.grid
             .convolve(
                 &mut lumi_cache,
-                &order_mask.map_or(vec![], |b| b.to_vec().unwrap()),
-                &bin_indices.map_or(vec![], |c| c.to_vec().unwrap()),
-                &channel_mask.map_or(vec![], |d| d.to_vec().unwrap()),
+                &order_mask.map_or(vec![], |b| b.to_vec()),
+                &bin_indices.map_or(vec![], |c| c.to_vec()),
+                &channel_mask.map_or(vec![], |d| d.to_vec()),
                 &xi.map_or(vec![(1.0, 1.0)], |m| m),
             )
             .into_pyarray_bound(py)

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -280,10 +280,10 @@ impl PyGrid {
         self.grid
             .convolve(
                 &mut lumi_cache,
-                &order_mask.map_or(vec![], |b| b.to_vec()),
-                &bin_indices.map_or(vec![], |c| c.to_vec()),
-                &channel_mask.map_or(vec![], |d| d.to_vec()),
-                &xi.map_or(vec![(1.0, 1.0)], |m| m),
+                &order_mask.unwrap_or(vec![]),
+                &bin_indices.unwrap_or(vec![]),
+                &channel_mask.unwrap_or(vec![]),
+                &xi.unwrap_or(vec![(1.0, 1.0)]),
             )
             .into_pyarray_bound(py)
     }
@@ -347,10 +347,10 @@ impl PyGrid {
         self.grid
             .convolve(
                 &mut lumi_cache,
-                &order_mask.map_or(vec![], |b| b.to_vec()),
-                &bin_indices.map_or(vec![], |c| c.to_vec()),
-                &channel_mask.map_or(vec![], |d| d.to_vec()),
-                &xi.map_or(vec![(1.0, 1.0)], |m| m),
+                &order_mask.unwrap_or(vec![]),
+                &bin_indices.unwrap_or(vec![]),
+                &channel_mask.unwrap_or(vec![]),
+                &xi.unwrap_or(vec![(1.0, 1.0)]),
             )
             .into_pyarray_bound(py)
     }

--- a/pineappl_py/src/import_only_subgrid.rs
+++ b/pineappl_py/src/import_only_subgrid.rs
@@ -1,7 +1,7 @@
 //! PyImportOnlySubgrid* interface.
 
 use super::subgrid::PySubgridEnum;
-use numpy::{PyArrayMethods, PyReadonlyArray1, PyReadonlyArray3};
+use numpy::PyReadonlyArray3;
 use pineappl::import_only_subgrid::ImportOnlySubgridV1;
 use pineappl::import_only_subgrid::ImportOnlySubgridV2;
 use pineappl::sparse_array3::SparseArray3;
@@ -34,14 +34,10 @@ impl PyImportOnlySubgridV2 {
     pub fn new(
         array: PyReadonlyArray3<f64>,
         mu2_grid: Vec<(f64, f64)>,
-        x1_grid: PyReadonlyArray1<f64>,
-        x2_grid: PyReadonlyArray1<f64>,
+        x1_grid: Vec<f64>,
+        x2_grid: Vec<f64>,
     ) -> Self {
-        let mut sparse_array = SparseArray3::new(
-            mu2_grid.len(),
-            x1_grid.as_slice().unwrap().len(),
-            x2_grid.as_slice().unwrap().len(),
-        );
+        let mut sparse_array = SparseArray3::new(mu2_grid.len(), x1_grid.len(), x2_grid.len());
 
         for ((imu2, ix1, ix2), value) in array
             .as_array()
@@ -60,8 +56,8 @@ impl PyImportOnlySubgridV2 {
                         fac: *fac,
                     })
                     .collect(),
-                x1_grid.to_vec().unwrap(),
-                x2_grid.to_vec().unwrap(),
+                x1_grid,
+                x2_grid,
             ),
         }
     }
@@ -112,15 +108,11 @@ impl PyImportOnlySubgridV1 {
     #[new]
     pub fn new_import_only_subgrid(
         array: PyReadonlyArray3<f64>,
-        q2_grid: PyReadonlyArray1<f64>,
-        x1_grid: PyReadonlyArray1<f64>,
-        x2_grid: PyReadonlyArray1<f64>,
+        q2_grid: Vec<f64>,
+        x1_grid: Vec<f64>,
+        x2_grid: Vec<f64>,
     ) -> Self {
-        let mut sparse_array = SparseArray3::new(
-            q2_grid.as_slice().unwrap().len(),
-            x1_grid.as_slice().unwrap().len(),
-            x2_grid.as_slice().unwrap().len(),
-        );
+        let mut sparse_array = SparseArray3::new(q2_grid.len(), x1_grid.len(), x2_grid.len());
 
         for ((iq2, ix1, ix2), value) in array
             .as_array()
@@ -132,9 +124,9 @@ impl PyImportOnlySubgridV1 {
 
         Self::new(ImportOnlySubgridV1::new(
             sparse_array,
-            q2_grid.to_vec().unwrap(),
-            x1_grid.to_vec().unwrap(),
-            x2_grid.to_vec().unwrap(),
+            q2_grid,
+            x1_grid,
+            x2_grid,
         ))
     }
 

--- a/pineappl_py/tests/test_grid.py
+++ b/pineappl_py/tests/test_grid.py
@@ -96,13 +96,48 @@ class TestGrid:
             g.convolve_with_one(2212, lambda pid, x, q2: 0.0, lambda q2: 0.0),
             [0.0] * 2,
         )
+        v = 5e6 / 9999
         np.testing.assert_allclose(
             g.convolve_with_one(2212, lambda pid, x, q2: 1, lambda q2: 1.0),
-            [5e6 / 9999, 0.0],
+            [v, 0.0],
+        )
+        np.testing.assert_allclose(
+            g.convolve_with_one(
+                2212, lambda pid, x, q2: 1, lambda q2: 1.0, bin_indices=[0]
+            ),
+            [v],
+        )
+        # block first bins with additional args
+        np.testing.assert_allclose(
+            g.convolve_with_one(
+                2212,
+                lambda pid, x, q2: 1,
+                lambda q2: 1.0,
+                bin_indices=[0],
+                order_mask=[False],
+            ),
+            [0.0],
+        )
+        np.testing.assert_allclose(
+            g.convolve_with_one(
+                2212,
+                lambda pid, x, q2: 1,
+                lambda q2: 1.0,
+                bin_indices=[0],
+                channel_mask=[False],
+            ),
+            [0.0],
+        )
+        # second bin is empty
+        np.testing.assert_allclose(
+            g.convolve_with_one(
+                2212, lambda pid, x, q2: 1, lambda q2: 1.0, bin_indices=[1]
+            ),
+            [0.0],
         )
         np.testing.assert_allclose(
             g.convolve_with_one(2212, lambda pid, x, q2: 1, lambda q2: 2.0),
-            [2**3 * 5e6 / 9999, 0.0],
+            [2**3 * v, 0.0],
         )
 
     def test_io(self, tmp_path):


### PR DESCRIPTION
I could not find back the comment of @cschwan where he was asking about why we're using sometimes `Vec` and sometime `PyReadonlyArray` and @Radonirinaunimi replied, that should not make a difference. The unit tests here prove it does make a difference (i.e. they will not pass without the changes in the interface) and the correct thing is to use `Vec`.

Else you get
```
        np.testing.assert_allclose(
>           g.convolve_with_one(2212, lambda pid, x, q2: 1, lambda q2: 1.0,bin_indices=[0]),
            [v],
        )
E       TypeError: argument 'bin_indices': 'list' object cannot be converted to 'PyArray<T, D>'

tests/test_grid.py:105: TypeError
```
and likewise wrapping in `np.array` does not work
```
        np.testing.assert_allclose(
>           g.convolve_with_one(2212, lambda pid, x, q2: 1, lambda q2: 1.0,bin_indices=np.array([0])),
            [v],
        )
E       TypeError: argument 'bin_indices': 'ndarray' object cannot be converted to 'PyArray<T, D>'

tests/test_grid.py:105: TypeError
```

however, this must have changed recently (e.g. in #302) because in v0.7.4 where I was hit by the problem I could still do
```python
    order_mask = pineappl.grid.Order.create_mask(grid.orders(), 2 - 1 + pto_, 0, True)
    for lu, lab in enumerate(("gg", "qqbar", "gq")):
        lumi_mask = [False] * 6
        lumi_mask[lu] = True
        df[lab] = grid.convolute_with_one(
            2212,
            extra.masked_xfxQ2(central_pdf),
            central_pdf.alphasQ2,
            lumi_mask=lumi_mask,
            order_mask=order_mask,
        )
```

also note that in v0.7.4 the error is slightly different:
```
return self.raw.convolute_with_two(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument 'bin_indices': type mismatch:
 from=int64, to=uint64
```
do we want to keep fixing former version, or not? (else I can work around that - I was too lazy so far to upgrade to v0.8 as it is a major change and I know v0.9 will be as well)

