### PR TITLE
Add alternative development using Nix

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -196,7 +196,40 @@ If you'd like to convert NNPDF's legacy FK tables to PineAPPL grids, add the swi
 
 #### Alternative: development version
 
-To use the most recent version available run
+An alternative way to easily get started with building `pineappl` is to use
+[nix-shell](https://nixos.wiki/wiki/Development_environment_with_nix-shell).
+`nix-shell` is a powerful tool from the [Nix](https://nixos.org/) ecosystem
+that provides a reproducible development environment without modifying the
+system's global state. It is especially convenient when building `pineappl_cli`
+with the various features such as `APPLgrid` or `fastNLO`.
+
+The interactive nix-based shell and its package manager can be easily installed
+using the OS' package manager by following the instructions on
+[this page](https://nixos.org/download/#download-nix).
+
+To use `nix-shell`, simply create a `shell.nix` file in the working directory with
+the following contents:
+```nix
+with import <nixpkgs> {}; {
+  qpidEnv = stdenvNoCC.mkDerivation {
+    name = "build-pineappl";
+    buildInputs = [
+        gcc
+        gfortran
+        lhapdf
+        cargo
+        cargo-c
+    ];
+  };
+}
+```
+This will provide all the necessary dependencies to build `pineappl` as well as its
+C-/Fortran APIs and CLI version. Finally, to invoke the shell, simply run:
+```
+nix-shell
+```
+
+When building the `pineappl_cli`, in order to use the most recent version available run
 
     cargo install --locked --git https://github.com/NNPDF/pineappl.git pineappl_cli
 


### PR DESCRIPTION
Adds a documentation on alternatively building `pineappl` with `nix-shell`.