### PR TITLE
Allow a generic number of `EKOs` to be passed to `pineappl evolve`

### DIFF
--- a/docs/cli-tutorial.md
+++ b/docs/cli-tutorial.md
@@ -60,6 +60,44 @@ Let's have a closer look at what the output shows:
 - the last column `dsig/detal` shows the differential cross section (`dsig`)
   for the bin limits given in the previous two columns.
 
+In the case where the grid requires different types of convolution functions,
+the LHAPDF names need to be appended with `+p`, `+f`, or `+pf` (equivalently
+`+fp`) which respectively correspond to polarized, fragmentation function, or
+both.
+
+As an example, let's download a grid that contains one polarized and one
+unpolarized proton:
+```
+wget 'https://data.nnpdf.science/pineappl/test-data/STAR_WMWP_510GEV_WM-AL-POL.pineappl.lz4'
+```
+
+Then, to perform the convolution, run the following command:
+```
+pineappl convolve STAR_WMWP_510GEV_WM-AL-POL.pineappl.lz4 NNPDFpol11_100+p,CT18NNLO
+```
+
+where we specified the PDF set `NNPDFpol10_100` to be polarized. Note that
+the order in which the PDF sets are passed do not matter; `pineappl` will
+automatically identify which object should be convolved with a given PDF set.
+
+If successful, the command above should print the following result (again the
+numbers don't really matter):
+```
+b                  eta                   dsig/deta
+                   []                      [pb]
+-+------------------+------------------+-----------
+0               -1.5                 -1 7.6327588e1
+1                 -1               -0.5 5.6712977e2
+2               -0.5                  0 1.8279428e3
+3                  0 0.4999999999999999 3.5666164e3
+4 0.4999999999999999                  1 3.9650498e3
+5                  1                1.5 1.2597799e3
+```
+
+By default, `pineappl` uses the first PDF set to compute the value of
+$\alpha_s(Q^2)$. This can be changed by passing the position of the PDF set as
+an index (starting from `0`) to the `--use-alphas-from` flag.
+
 ## `pineappl -h`: Getting help
 
 One of the most difficult aspects of learning a new program is remembering how

--- a/docs/cli-tutorial.md
+++ b/docs/cli-tutorial.md
@@ -62,8 +62,8 @@ Let's have a closer look at what the output shows:
 
 In the case where the grid requires different types of convolution functions,
 the LHAPDF names need to be appended with `+p`, `+f`, or `+pf` (equivalently
-`+fp`) which respectively correspond to polarized, fragmentation function, or
-both.
+`+fp`) which respectively correspond to a polarized PDF, a fragmentation function, or
+a polarized fragmentation function.
 
 As an example, let's download a grid that contains one polarized and one
 unpolarized proton:

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1225,20 +1225,10 @@ impl Grid {
                 perm = self
                     .convolutions()
                     .iter()
-                    .enumerate()
-                    .map(|(max_idx, conv)| {
+                    .map(|conv| {
                         eko_conv_types
                             .iter()
-                            .take(max_idx + 1)
-                            .enumerate()
-                            .rev()
-                            .find_map(|(idx, &eko_conv_type)| {
-                                if conv.conv_type() == eko_conv_type {
-                                    Some(idx)
-                                } else {
-                                    None
-                                }
-                            })
+                            .position(|idx| idx == &conv.conv_type())
                             // TODO: convert `unwrap` to `Err`
                             .unwrap()
                     })

--- a/pineappl_cli/src/evolve.rs
+++ b/pineappl_cli/src/evolve.rs
@@ -1,4 +1,4 @@
-use super::helpers::{self, ConvFuns, ConvoluteMode, EkoPaths};
+use super::helpers::{self, ConvFuns, ConvoluteMode};
 use super::{GlobalConfiguration, Subcommand};
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueHint};
@@ -492,7 +492,7 @@ pub struct Opts {
     input: PathBuf,
     /// Path to the evolution kernel operator(s).
     #[arg(value_name = "EKOs")]
-    ekos: EkoPaths,
+    ekos: String,
     /// Path to the converted grid.
     #[arg(value_hint = ValueHint::FilePath)]
     output: PathBuf,
@@ -545,7 +545,7 @@ impl Subcommand for Opts {
             cfg,
         );
 
-        let ekonames = helpers::create_eko_paths(&self.ekos, &self.conv_funs.conv_types);
+        let ekonames = helpers::parse_ekos(&self.ekos);
         let fk_table = evolve_grid(
             &grid,
             &ekonames,

--- a/pineappl_cli/src/evolve.rs
+++ b/pineappl_cli/src/evolve.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueHint};
 use lhapdf::Pdf;
 use pineappl::fk_table::FkTable;
 use pineappl::grid::Grid;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 #[cfg(feature = "evolve")]
@@ -438,7 +438,7 @@ mod eko {
 #[cfg(feature = "evolve")]
 fn evolve_grid(
     grid: &Grid,
-    ekos: &[PathBuf],
+    ekos: &[&Path],
     use_alphas_from: &Pdf,
     orders: &[(u8, u8)],
     xir: f64,
@@ -461,7 +461,7 @@ fn evolve_grid(
 
     let mut eko_slices: Vec<_> = ekos
         .iter()
-        .map(|eko| EkoSlices::new(eko.as_path()))
+        .map(|eko| EkoSlices::new(eko))
         .collect::<Result<_, _>>()?;
     let eko_slices: Vec<_> = eko_slices.iter_mut().collect();
     let alphas_table = AlphasTable::from_grid(grid, xir, &|q2| use_alphas_from.alphas_q2(q2));
@@ -545,7 +545,7 @@ impl Subcommand for Opts {
             cfg,
         );
 
-        let eko_paths: Vec<_> = self.ekos.split(',').map(PathBuf::from).collect();
+        let eko_paths: Vec<_> = self.ekos.split(',').map(Path::new).collect();
         let fk_table = evolve_grid(
             &grid,
             &eko_paths,

--- a/pineappl_cli/src/evolve.rs
+++ b/pineappl_cli/src/evolve.rs
@@ -1,4 +1,4 @@
-use super::helpers::{self, ConvFuns, ConvoluteMode, EkoNames};
+use super::helpers::{self, ConvFuns, ConvoluteMode, EkoPaths};
 use super::{GlobalConfiguration, Subcommand};
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueHint};
@@ -492,7 +492,7 @@ pub struct Opts {
     input: PathBuf,
     /// Path to the evolution kernel operator(s).
     #[arg(value_name = "EKOs")]
-    ekos: EkoNames,
+    ekos: EkoPaths,
     /// Path to the converted grid.
     #[arg(value_hint = ValueHint::FilePath)]
     output: PathBuf,

--- a/pineappl_cli/src/evolve.rs
+++ b/pineappl_cli/src/evolve.rs
@@ -491,7 +491,7 @@ pub struct Opts {
     #[arg(value_hint = ValueHint::FilePath)]
     input: PathBuf,
     /// Path to the evolution kernel operator(s).
-    #[arg(value_name = "EKOs")]
+    #[arg(value_name = "EKO1,...")]
     ekos: String,
     /// Path to the converted grid.
     #[arg(value_hint = ValueHint::FilePath)]

--- a/pineappl_cli/src/evolve.rs
+++ b/pineappl_cli/src/evolve.rs
@@ -545,10 +545,10 @@ impl Subcommand for Opts {
             cfg,
         );
 
-        let ekonames = helpers::parse_ekos(&self.ekos);
+        let eko_paths: Vec<_> = self.ekos.split(',').map(PathBuf::from).collect();
         let fk_table = evolve_grid(
             &grid,
-            &ekonames,
+            &eko_paths,
             &conv_funs[cfg.use_alphas_from],
             &self.orders,
             self.xir,

--- a/pineappl_cli/src/helpers.rs
+++ b/pineappl_cli/src/helpers.rs
@@ -15,58 +15,6 @@ use std::process::ExitCode;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EkoPaths {
-    pub eko_names: Vec<String>,
-    pub conv_types: Vec<ConvType>,
-}
-
-impl FromStr for EkoPaths {
-    type Err = Error;
-
-    fn from_str(arg: &str) -> std::result::Result<Self, Self::Err> {
-        let (eko_names, conv_types) = arg
-            .split(',')
-            .map(|fun| {
-                let (name, typ) = fun.split_once('+').unwrap_or((fun, ""));
-                let name = name.to_owned();
-
-                let typ = match typ {
-                    "" => ConvType::UnpolPDF,
-                    "p" => ConvType::PolPDF,
-                    "f" => ConvType::UnpolFF,
-                    "pf" | "fp" => ConvType::PolFF,
-                    _ => bail!("unknown convolution type '{typ}'"),
-                };
-                Ok::<_, Error>((name, typ))
-            })
-            .collect::<Result<Vec<(String, ConvType)>>>()?
-            .into_iter()
-            .multiunzip();
-
-        Ok(Self {
-            eko_names,
-            conv_types,
-        })
-    }
-}
-
-pub fn create_eko_paths(eko_obj: &EkoPaths, conv_types: &[ConvType]) -> Vec<PathBuf> {
-    let vec_ekonames: Vec<String> = conv_types
-        .iter()
-        .map(|convtype| {
-            let eko_cv_idx = eko_obj
-                .conv_types
-                .iter()
-                .position(|&x| x == *convtype)
-                .unwrap_or(0);
-            eko_obj.eko_names[eko_cv_idx].clone()
-        })
-        .collect();
-
-    vec_ekonames.iter().map(PathBuf::from).collect()
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConvFuns {
     pub lhapdf_names: Vec<String>,
     pub members: Vec<Option<usize>>,
@@ -515,6 +463,11 @@ pub fn parse_order(order: &str) -> Result<(u8, u8)> {
     }
 
     Ok((alphas, alpha))
+}
+
+pub fn parse_ekos(ekos_str: &str) -> Vec<PathBuf> {
+    let eko_names = ekos_str.split(',');
+    eko_names.into_iter().map(PathBuf::from).collect()
 }
 
 #[cfg(test)]

--- a/pineappl_cli/src/helpers.rs
+++ b/pineappl_cli/src/helpers.rs
@@ -10,7 +10,7 @@ use prettytable::Table;
 use std::fs::{File, OpenOptions};
 use std::iter;
 use std::ops::RangeInclusive;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::ExitCode;
 use std::str::FromStr;
 
@@ -463,11 +463,6 @@ pub fn parse_order(order: &str) -> Result<(u8, u8)> {
     }
 
     Ok((alphas, alpha))
-}
-
-pub fn parse_ekos(ekos_str: &str) -> Vec<PathBuf> {
-    let eko_names = ekos_str.split(',');
-    eko_names.into_iter().map(PathBuf::from).collect()
 }
 
 #[cfg(test)]

--- a/pineappl_cli/src/helpers.rs
+++ b/pineappl_cli/src/helpers.rs
@@ -15,12 +15,12 @@ use std::process::ExitCode;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EkoNames {
+pub struct EkoPaths {
     pub eko_names: Vec<String>,
     pub conv_types: Vec<ConvType>,
 }
 
-impl FromStr for EkoNames {
+impl FromStr for EkoPaths {
     type Err = Error;
 
     fn from_str(arg: &str) -> std::result::Result<Self, Self::Err> {
@@ -50,7 +50,7 @@ impl FromStr for EkoNames {
     }
 }
 
-pub fn create_eko_paths(eko_obj: &EkoNames, conv_types: &[ConvType]) -> Vec<PathBuf> {
+pub fn create_eko_paths(eko_obj: &EkoPaths, conv_types: &[ConvType]) -> Vec<PathBuf> {
     let vec_ekonames: Vec<String> = conv_types
         .iter()
         .map(|convtype| {

--- a/pineappl_cli/tests/convolve.rs
+++ b/pineappl_cli/tests/convolve.rs
@@ -36,7 +36,8 @@ const DEFAULT_STR: &str = "b   etal    dsig/detal
 7    4  4.5 2.7517266e1
 ";
 
-const USE_ALPHAS_FROM_ERROR_STR: &str = "expected `use_alphas_from` to be `0` or `1`, is `2`
+const USE_ALPHAS_FROM_ERROR_STR: &str =
+    "expected `use_alphas_from` to be an integer within `[0, 2)`, but got `2`
 ";
 
 const FORCE_POSITIVE_STR: &str = "b   etal    dsig/detal 

--- a/pineappl_cli/tests/evolve.rs
+++ b/pineappl_cli/tests/evolve.rs
@@ -6,11 +6,11 @@ use assert_fs::NamedTempFile;
 
 const HELP_STR: &str = "Evolve a grid with an evolution kernel operator to an FK table
 
-Usage: pineappl evolve [OPTIONS] <INPUT> <EKOs> <OUTPUT> <CONV_FUNS>
+Usage: pineappl evolve [OPTIONS] <INPUT> <EKO1,...> <OUTPUT> <CONV_FUNS>
 
 Arguments:
   <INPUT>      Path to the input grid
-  <EKOs>       Path to the evolution kernel operator(s)
+  <EKO1,...>   Path to the evolution kernel operator(s)
   <OUTPUT>     Path to the converted grid
   <CONV_FUNS>  LHAPDF ID(s) or name of the PDF(s)/FF(s)
 

--- a/pineappl_cli/tests/evolve.rs
+++ b/pineappl_cli/tests/evolve.rs
@@ -6,16 +6,15 @@ use assert_fs::NamedTempFile;
 
 const HELP_STR: &str = "Evolve a grid with an evolution kernel operator to an FK table
 
-Usage: pineappl evolve [OPTIONS] <INPUT> <EKO> <OUTPUT> <CONV_FUNS>
+Usage: pineappl evolve [OPTIONS] <INPUT> <EKOs> <OUTPUT> <CONV_FUNS>
 
 Arguments:
   <INPUT>      Path to the input grid
-  <EKO>        Path to the evolution kernel operator
+  <EKOs>       Path to the evolution kernel operator(s)
   <OUTPUT>     Path to the converted grid
   <CONV_FUNS>  LHAPDF ID(s) or name of the PDF(s)/FF(s)
 
 Options:
-      --ekob <EKOB>          Additional path to the 2nd evolution kernel operator
       --accuracy <ACCURACY>  Relative threshold between the table and the converted grid when comparison fails [default: 1e-3]
       --digits-abs <ABS>     Set the number of fractional digits shown for absolute numbers [default: 7]
       --digits-rel <REL>     Set the number of fractional digits shown for relative numbers [default: 7]
@@ -428,15 +427,15 @@ fn cms_ttb_8tev_2d_ttm_trap_tot() {
 fn star_wmwp_510gev_wm_al_pol() {
     let output = NamedTempFile::new("fktable6.lz4").unwrap();
 
+    // Here the order of the EKOs are swapped to check that mapping convtype is working
     Command::cargo_bin("pineappl")
         .unwrap()
         .args([
             "evolve",
             "../test-data/STAR_WMWP_510GEV_WM-AL-POL.pineappl.lz4",
-            "../test-data/STAR_WMWP_510GEV_WM-AL-POL_PolPDF.tar",
+            "../test-data/STAR_WMWP_510GEV_WM-AL-POL_UnpolPDF.tar,../test-data/STAR_WMWP_510GEV_WM-AL-POL_PolPDF.tar+p",
             output.path().to_str().unwrap(),
             "240608-tr-pol-nlo-100+p,NNPDF40_nlo_pch_as_01180",
-            "--ekob=../test-data/STAR_WMWP_510GEV_WM-AL-POL_UnpolPDF.tar",
         ])
         .assert()
         .success()

--- a/pineappl_cli/tests/evolve.rs
+++ b/pineappl_cli/tests/evolve.rs
@@ -427,13 +427,14 @@ fn cms_ttb_8tev_2d_ttm_trap_tot() {
 fn star_wmwp_510gev_wm_al_pol() {
     let output = NamedTempFile::new("fktable6.lz4").unwrap();
 
-    // Here the order of the EKOs are swapped to check that mapping convtype is working
+    // Grid is (PolPDF, UnpolPDF) but EKOs are ordered as {UnpolEko, PolEko} to
+    // check that order doesn't matter.
     Command::cargo_bin("pineappl")
         .unwrap()
         .args([
             "evolve",
             "../test-data/STAR_WMWP_510GEV_WM-AL-POL.pineappl.lz4",
-            "../test-data/STAR_WMWP_510GEV_WM-AL-POL_UnpolPDF.tar,../test-data/STAR_WMWP_510GEV_WM-AL-POL_PolPDF.tar+p",
+            "../test-data/STAR_WMWP_510GEV_WM-AL-POL_UnpolPDF.tar,../test-data/STAR_WMWP_510GEV_WM-AL-POL_PolPDF.tar",
             output.path().to_str().unwrap(),
             "240608-tr-pol-nlo-100+p,NNPDF40_nlo_pch_as_01180",
         ])


### PR DESCRIPTION
This addresses #330.

Things to do:
- [x] rename `EkoNames` to `EkoPaths`
- [x] ~find a robust and stable way to parse multiple EKOs~
- [x] rely on information inside the EKOs to derive the types of convolutions
- [x] add minor tutorial on the use of `p,f,pf,fp`markings in multi-convolution