### PR TITLE
Bum MSRV to 1.94.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- raised MSRV to 1.94.0
+
 ## [1.3.3] - 01/03/2026
 
 ## Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,6 @@ increasing the MSRV make sure to set it everywhere to the same value:
    - in all Github workflows (`.github/workflows/`)
    - in `.readthedocs.yml` update the value of the `rust` field and make sure
      [RTD supports it](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-rust)
-   - in `make_release.sh` update the `cargo msrv` call
 4. commit the previous changes and push them *after* the container created by
    step 2 is ready
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2021"
 keywords = ["high-energy-physics", "physics"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/NNPDF/pineappl"
-rust-version = "1.80.1"
+rust-version = "1.94.0"
 version = "1.3.3"
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/gh/NNPDF/pineappl/branch/master/graph/badge.svg)](https://codecov.io/gh/NNPDF/pineappl)
 [![Documentation](https://docs.rs/pineappl/badge.svg)](https://docs.rs/pineappl)
 [![crates.io](https://img.shields.io/crates/v/pineappl.svg)](https://crates.io/crates/pineappl)
-[![MSRV](https://img.shields.io/badge/Rust-1.80+-lightgray.svg)](docs/installation.md)
+[![MSRV](https://img.shields.io/badge/Rust-1.94+-lightgray.svg)](docs/installation.md)
 
 # What is PineAPPL?
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -251,7 +251,7 @@ already installed, make sure it is recent enough:
 
     cargo --version
 
-This should show a version that is at least 1.80.1. If you do not have `cargo`
+This should show a version that is at least 1.94.0. If you do not have `cargo`
 or if it is too old, go to <https://www.rust-lang.org/tools/install> and follow
 the instructions there.
 


### PR DESCRIPTION
Furthermore, the version in the container has been updated to the following in e75e6a2ed104e3e6c09f9b9d6feae6a69a1a5962:
```sh
RUST_V="1.80.1 1.94.0 nightly-2026-03-10"
```
https://github.com/NNPDF/pineappl/pull/381 could also be implemented here.