### PR TITLE
Fix fastNLO import with two scales

### DIFF
--- a/pineappl_cli/src/import/fastnlo.rs
+++ b/pineappl_cli/src/import/fastnlo.rs
@@ -438,8 +438,6 @@ fn convert_coeff_add_flex(
                         if npdf == 1 {
                             array[[is1, is2, ix1]] = value * factor * x1_values[ix1];
                         } else if npdf == 2 {
-                            assert_eq!(is2, 0);
-
                             array[[is1, is2, ix1, ix2]] =
                                 value * factor * x1_values[ix1] * x2_values[ix2];
                         }
@@ -466,8 +464,7 @@ fn convert_coeff_add_flex(
                 } else {
                     vec![
                         scale_nodes1.iter().map(|s| s * s).collect(),
-                        // scale_nodes2.iter().map(|s| s * s).collect(),
-                        vec![100000.0],
+                        scale_nodes2.iter().map(|s| s * s).collect(),
                         x1_values.clone(),
                         x2_values.clone(),
                     ]


### PR DESCRIPTION
This should address #383. Not really sure why it was always assumed for the two scales to be the same but removing that check solves the issue.